### PR TITLE
Extract paths to new classes

### DIFF
--- a/src/AbstractPathProvider.php
+++ b/src/AbstractPathProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Actengage\Deployer;
+
+use Actengage\Deployer\Contracts\PathProvider;
+use Illuminate\Support\Str;
+
+/**
+ * Provides necessary file paths.
+ *
+ * An abstract implementation of `PathProvider` that resolves relative file paths from the deployment root.
+ */
+abstract class AbstractPathProvider implements PathProvider
+{
+    public function __construct(protected FilesystemUtility $filesystem, protected string $deploymentDir)
+    {
+    }
+
+    public function bundlesDir(): string
+    {
+        return $this->resolvePath($this->unresolvedBundlesDir());
+    }
+
+    public function extractionDir(): string
+    {
+        return $this->resolvePath($this->unresolvedExtractionDir());
+    }
+
+    public function backupDir(): string
+    {
+        return $this->resolvePath($this->unresolvedBackupDir());
+    }
+
+    public function deploymentDir(): string
+    {
+        return $this->deploymentDir;
+    }
+
+    /**
+     * Gets the unresolved bundles dir.
+     * 
+     * Should get the raw, unresolved path to the bundles directory. It will be resolved from the deployment root.
+     * 
+     * @return string
+     */
+    protected abstract function unresolvedBundlesDir(): string;
+
+    /**
+     * Gets the unresolved extraction dir.
+     * 
+     * Should get the raw, unresolved path to the extraction directory. It will be resolved from the deployment root.
+     * 
+     * @return string
+     */
+    protected abstract function unresolvedExtractionDir(): string;
+
+    /**
+     * Gets the unresolved backup dir.
+     * 
+     * Should get the raw, unresolved path to the backup directory. It will be resolved from the deployment root.
+     * 
+     * @return string
+     */
+    protected abstract function unresolvedBackupDir(): string;
+
+    /**
+     * Resolves the given path.
+     * 
+     * Resolves the given path from the deployment root.
+     * 
+     * @param string $path the path to resolves.
+     * @return string the resolved path.
+     */
+    protected function resolvePath(string $path): string
+    {
+        if (Str::startsWith($path, '/')) {
+            return $path;
+        }
+
+        return $this->filesystem->joinPaths($this->deploymentDir, $path);
+    }
+}

--- a/src/PathProvider.php
+++ b/src/PathProvider.php
@@ -2,51 +2,25 @@
 
 namespace Actengage\Deployer;
 
-use Actengage\Deployer\Contracts\PathProvider as PathProviderInterface;
-use Illuminate\Support\Str;
-
-/**
- * Provides necessary file paths.
- *
- * An implementation of `IPathProvider` that resolves relative file paths from the deployment root.
- */
-class PathProvider implements PathProviderInterface
+class PathProvider extends AbstractPathProvider
 {
-    public function __construct(
-        protected FilesystemUtility $filesystem,
-        protected string $bundlesDir,
-        protected string $extractionDir,
-        protected string $backupDir,
-        protected string $deploymentDir
-    ) {
+    public function __construct(FilesystemUtility $filesystem, string $deploymentDir)
+    {
+        parent::__construct($filesystem, $deploymentDir);
     }
 
-    public function bundlesDir(): string
+    protected function unresolvedBundlesDir(): string
     {
-        return $this->resolvePath($this->bundlesDir);
+        return config('deployer.bundles_dir');
     }
 
-    public function extractionDir(): string
+    protected function unresolvedExtractionDir(): string
     {
-        return $this->resolvePath($this->extractionDir);
+        return config('deployer.extraction_dir');
     }
 
-    public function backupDir(): string
+    protected function unresolvedBackupDir(): string
     {
-        return $this->resolvePath($this->backupDir);
-    }
-
-    public function deploymentDir(): string
-    {
-        return $this->deploymentDir;
-    }
-
-    protected function resolvePath(string $path)
-    {
-        if (Str::startsWith($path, '/')) {
-            return $path;
-        }
-
-        return $this->filesystem->joinPaths($this->deploymentDir, $path);
+        return config('deployer.backup_dir');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -32,18 +32,6 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(PathProviderInterface::class, PathProvider::class);
 
         $this->app->when(PathProvider::class)
-            ->needs('$bundlesDir')
-            ->giveConfig('deployer.bundles_dir');
-
-        $this->app->when(PathProvider::class)
-            ->needs('$extractionDir')
-            ->giveConfig('deployer.extraction_dir');
-
-        $this->app->when(PathProvider::class)
-            ->needs('$backupDir')
-            ->giveConfig('deployer.backup_dir');
-
-        $this->app->when(PathProvider::class)
             ->needs('$deploymentDir')
             ->give(getcwd());
 

--- a/tests/Support/PathProvider.php
+++ b/tests/Support/PathProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Support;
+
+use Actengage\Deployer\AbstractPathProvider;
+use Actengage\Deployer\FilesystemUtility;
+
+class PathProvider extends AbstractPathProvider
+{
+    public function __construct(FilesystemUtility $filesystem, protected string $testsDir)
+    {
+        parent::__construct($filesystem, $testsDir.'storage/app');
+    }
+
+    protected function unresolvedBundlesDir(): string
+    {
+        return $this->testsDir.'storage/bundles/deeply/nested';
+    }
+
+    protected function unresolvedExtractionDir(): string
+    {
+        return $this->testsDir.'storage/path/to/extraction/dir';
+    }
+
+    protected function unresolvedBackupDir(): string
+    {
+        return $this->testsDir.'storage/backups';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@ use Actengage\Deployer\BundleDeployer;
 use Actengage\Deployer\BundleExtractor;
 use Actengage\Deployer\Contracts\PathProvider as PathProviderInterface;
 use Actengage\Deployer\FilesystemUtility;
-use Actengage\Deployer\PathProvider;
+use Tests\Support\PathProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use ReflectionClass;
 
@@ -39,20 +39,8 @@ class TestCase extends BaseTestCase
         $this->app->singleton(PathProviderInterface::class, PathProvider::class);
 
         $this->app->when(PathProvider::class)
-            ->needs('$bundlesDir')
-            ->give($this->testsDir().'storage/bundles/deeply/nested');
-
-        $this->app->when(PathProvider::class)
-            ->needs('$extractionDir')
-            ->give($this->testsDir().'storage/path/to/extraction/dir');
-
-        $this->app->when(PathProvider::class)
-            ->needs('$backupDir')
-            ->give($this->testsDir().'storage/backups');
-
-        $this->app->when(PathProvider::class)
-            ->needs('$deploymentDir')
-            ->give($this->testsDir().'storage/app');
+            ->needs('$testsDir')
+            ->give($this->testsDir());
 
         $this->app->when(BundleDeployer::class)
             ->needs('$artifactRules')


### PR DESCRIPTION
Extract the functionality that previously resided in ServiceProvider that acquired and resolved file paths to its own class.