### PR TITLE
Write `deployer:prune`

### DIFF
--- a/src/BundlePruner.php
+++ b/src/BundlePruner.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Actengage\Deployer;
+
+use Actengage\Deployer\Contracts\BundlesRepository;
+use Actengage\Deployer\Contracts\PathProvider;
+
+class BundlePruner
+{
+    public function __construct
+    (
+        protected FilesystemUtility $filesystem,
+        protected BundlesRepository $bundles,
+        protected LoggerRepository $logger
+    )
+    {
+    }
+
+    public function prune(int $keep): int
+    {
+        $deleted = 0;
+
+        $bundlesToDelete = $this->bundles->all()->skip($keep);
+        $bundlesToDelete->each(function (Bundle $bundle) use (&$deleted) {
+            $this->logger->get()->debug("Deleting bundle $bundle->path");
+            $this->filesystem->delete($bundle->path);
+            $deleted++;
+        });
+
+        return $deleted;
+    }
+}

--- a/src/BundlePruner.php
+++ b/src/BundlePruner.php
@@ -3,8 +3,14 @@
 namespace Actengage\Deployer;
 
 use Actengage\Deployer\Contracts\BundlesRepository;
+use Actengage\Deployer\Contracts\LoggerRepository;
 use Actengage\Deployer\Contracts\PathProvider;
 
+/**
+ * Prunes old bundles.
+ * 
+ * A class that is capable of removing old bundles from the bundles directory.
+ */
 class BundlePruner
 {
     public function __construct
@@ -16,13 +22,24 @@ class BundlePruner
     {
     }
 
+    /**
+     * Prunes old bundles.
+     * 
+     * Removes all bundles from disk except for the given number of most recent ones to keep.
+     * 
+     * Note that bundles with missing or malformed manifests will not be included (because it is impossible to
+     * accurately determine their timestamps).
+     * 
+     * @param int $keep the number of most recent bundles to keep.
+     * @return int the number of bundles that were deleted.
+     */
     public function prune(int $keep): int
     {
         $deleted = 0;
 
         $bundlesToDelete = $this->bundles->all()->skip($keep);
         $bundlesToDelete->each(function (Bundle $bundle) use (&$deleted) {
-            $this->logger->get()->debug("Deleting bundle $bundle->path");
+            $this->logger->get()->debug("Deleting bundle at $bundle->path");
             $this->filesystem->delete($bundle->path);
             $deleted++;
         });

--- a/src/BundlesRepository.php
+++ b/src/BundlesRepository.php
@@ -41,9 +41,7 @@ class BundlesRepository implements BundlesRepositoryInterface
     {
         $bundles = collect();
 
-        $bundlePaths = glob($this->filesystem->joinPaths($this->paths->bundlesDir(), '*'));
-
-        foreach ($bundlePaths as $bundlePath) {
+        $this->filesystem->eachChild($this->paths->bundlesDir(), function ($bundlePath) use ($bundles) {
             $bundle = $this->getBundle($bundlePath);
 
             if ($bundle) {
@@ -51,7 +49,7 @@ class BundlesRepository implements BundlesRepositoryInterface
             } else {
                 $this->logger->get()->info("Skipping $bundlePath because its manifest file was missing or malformed.");
             }
-        }
+        });
 
         if (! is_null($limit)) {
             $bundles = $bundles->take($limit);

--- a/src/Console/Commands/Prune.php
+++ b/src/Console/Commands/Prune.php
@@ -13,7 +13,7 @@ use Actengage\Deployer\Contracts\LoggerRepository;
  */
 final class Prune extends Command
 {
-    protected $signature = 'deployer:prune {--keep=5}';
+    protected $signature = 'deployer:prune {--keep=5} {--verbosity=1}';
 
     protected $description = 'Prunes old bundles from the bundles directory.';
 

--- a/src/Console/Commands/Prune.php
+++ b/src/Console/Commands/Prune.php
@@ -21,9 +21,13 @@ final class Prune extends Command
     {
         $logger->set($this->createLogger());
 
-        $deleted = $pruner->prune((int) $this->options('keep'));
+        $deleted = $pruner->prune((int) $this->option('keep'));
 
-        $this->info("Removed $deleted bundles.");
+        if ($deleted > 0) {
+            $this->info("Removed $deleted bundles.");
+        } else {
+            $this->info('No bundles to remove.');
+        }
 
         return 0;
     }

--- a/src/Console/Commands/Prune.php
+++ b/src/Console/Commands/Prune.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Actengage\Deployer\Console\Commands;
+
+use Actengage\Deployer\BundlePruner;
+use Actengage\Deployer\Console\Commands\Command;
+use Actengage\Deployer\Contracts\LoggerRepository;
+
+/**
+ * A command that prunes old bundles.
+ *
+ * A custom Artisan command that removes any old bundles in the bundles directory.
+ */
+final class Prune extends Command
+{
+    protected $signature = 'deployer:prune {--keep=5}';
+
+    protected $description = 'Prunes old bundles from the bundles directory.';
+
+    public function handle(LoggerRepository $logger, BundlePruner $pruner): int
+    {
+        $logger->set($this->createLogger());
+
+        $deleted = $pruner->prune((int) $this->options('keep'));
+
+        $this->info("Removed $deleted bundles.");
+
+        return 0;
+    }
+}

--- a/src/Contracts/BundlesRepository.php
+++ b/src/Contracts/BundlesRepository.php
@@ -19,6 +19,8 @@ interface BundlesRepository
      * 
      * Should get a collection containing all the `Bundle` instances in this bundle repository.
      * 
+     * The bundles should be sorted by timestamp in descending order.
+     * 
      * @param int $limit if given, specifies the maximum number of bundles to return.
      * @return Collection
      */

--- a/src/FilesystemUtility.php
+++ b/src/FilesystemUtility.php
@@ -43,6 +43,24 @@ class FilesystemUtility
     }
 
     /**
+     * Iterates over each directory child.
+     * 
+     * Iterates over every file and directory in the given directory, passing the full file path of each child to the
+     * callback.
+     * 
+     * @param string $path the path to the directory whose children should be iterated over.
+     * @param callable $callback the callback to invoke for each child.
+     * @return void
+     */
+    public function eachChild(string $path, callable $callback): void
+    {
+        $bundlePaths = glob($this->joinPaths($path, '*'));
+        foreach ($bundlePaths as $bundlePath) {
+            $callback($bundlePath);
+        }
+    }
+
+    /**
      * Deletes a file/directory.
      *
      * Recursively deletes the file or directory at the given path.
@@ -55,10 +73,9 @@ class FilesystemUtility
     public function delete(string $path): void
     {
         if (is_dir($path)) {
-            $files = glob($this->joinPaths($path, '*'), GLOB_MARK);
-            foreach ($files as $file) {
-                $this->delete($file);
-            }
+            $this->eachChild($path, function ($filePath) {
+                $this->delete($filePath);
+            });
             rmdir($path);
         } else {
             unlink($path);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,6 +34,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(FilesystemUtility::class);
         $this->app->singleton(ArtifactDeployer::class);
         $this->app->singleton(BundleDeployer::class);
+        $this->app->singleton(BundlePruner::class);
         $this->app->singleton(PathProviderInterface::class, PathProvider::class);
         $this->app->singleton(BundlesRepositoryInterface::class, BundlesRepository::class);
         $this->app->singleton(LoggerRepositoryInterface::class, LoggerRepository::class);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use Actengage\Deployer\Console\Commands\BundlesList;
 use Actengage\Deployer\Contracts\PathProvider as PathProviderInterface;
 use Actengage\Deployer\Contracts\BundlesRepository as BundlesRepositoryInterface;
 use Actengage\Deployer\BundlesRepository;
+use Actengage\Deployer\Console\Commands\Prune;
 use Actengage\Deployer\Contracts\LoggerRepository as LoggerRepositoryInterface;
 use Actengage\Deployer\LoggerRepository;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
@@ -25,7 +26,8 @@ class ServiceProvider extends BaseServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Artifacts::class,
-                BundlesList::class
+                BundlesList::class,
+                Prune::class
             ]);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Actengage\Deployer\ArtifactDeployer;
 use Actengage\Deployer\BundleDeployer;
+use Actengage\Deployer\BundlePruner;
 use Actengage\Deployer\Contracts\PathProvider as PathProviderInterface;
 use Actengage\Deployer\FilesystemUtility;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -36,6 +37,7 @@ class TestCase extends BaseTestCase
         $this->app->singleton(FilesystemUtility::class);
         $this->app->singleton(ArtifactDeployer::class);
         $this->app->singleton(BundleDeployer::class);
+        $this->app->singleton(BundlePruner::class);
         $this->app->singleton(PathProviderInterface::class, PathProvider::class);
         $this->app->singleton(LoggerRepositoryInterface::class, LoggerRepository::class);
 


### PR DESCRIPTION
This resolves #12 by adding a `deployer:prune` command to prune old bundles.