### PR TITLE
Properly index sorted bundles

### DIFF
--- a/src/BundlesAccessor.php
+++ b/src/BundlesAccessor.php
@@ -53,7 +53,7 @@ class BundlesAccessor
             $bundles = $bundles->take($limit);
         }
 
-        return $bundles;
+        return $bundles->values();
     }
 
     /**


### PR DESCRIPTION
In BundlesAccessor, after sorting bundles, make sure to properly reindex
them with `->values()`.
