### PR TITLE
Built-in command verbosity

### DIFF
--- a/src/Console/Commands/Command.php
+++ b/src/Console/Commands/Command.php
@@ -25,14 +25,29 @@ abstract class Command extends BaseCommand
      */
     protected function createLogger(): LoggerInterface
     {
-        $logLevel = match ((int) $this->option('verbosity')) {
+        $logLevel = match ((int) $this->getVerbosity()) {
             0 => LogLevel::ERROR,
             1 => LogLevel::NOTICE,
             2 => LogLevel::INFO,
-            default => LogLevel::DEBUG,
+            3 => LogLevel::DEBUG,
         };
 
         return new CommandLogger($this, $logLevel);
+    }
+
+    protected function getVerbosity(): int
+    {
+        $output = $this->getOutput();
+
+        if ($output->isDebug()) {
+            return 3;
+        } elseif ($output->isVeryVerbose()) {
+            return 2;
+        } elseif ($output->isVerbose()) {
+            return 2;
+        } else {
+            return 1;
+        }
     }
 
     /**

--- a/src/Console/Commands/Command.php
+++ b/src/Console/Commands/Command.php
@@ -35,6 +35,16 @@ abstract class Command extends BaseCommand
         return new CommandLogger($this, $logLevel);
     }
 
+    /**
+     * Gets the command verbosity.
+     *
+     * Retrieves an integer representation of verbosity, from 0 to 3.
+     *
+     * Currently, this is done by using `$this->getOutput()` to determine whether `-v`, `-vv`, or `-vvv` was passed to
+     * the command.
+     *
+     * @return int an integer representing the requested verbosity, from 0 to 3.
+     */
     protected function getVerbosity(): int
     {
         $output = $this->getOutput();

--- a/src/Console/Commands/Deploy.php
+++ b/src/Console/Commands/Deploy.php
@@ -22,8 +22,7 @@ final class Deploy extends Command
                             {--C|current}
                             {--c|commit=none}
                             {--r|bundle-version=none}
-                            {--N|number=none}
-                            {--verbosity=1}';
+                            {--N|number=none}';
 
     protected $description = 'Deploys an artifact bundle.';
 

--- a/src/Console/Commands/ListBundles.php
+++ b/src/Console/Commands/ListBundles.php
@@ -16,7 +16,7 @@ use Actengage\Deployer\CurrentBundleManager;
  */
 final class ListBundles extends Command
 {
-    protected $signature = 'deployer:list {--limit=10} {--verbosity=1}';
+    protected $signature = 'deployer:list {--limit=10}';
 
     protected $description = 'Lists all deployable artifact bundles.';
 

--- a/src/Console/Commands/Prune.php
+++ b/src/Console/Commands/Prune.php
@@ -12,7 +12,7 @@ use Actengage\Deployer\Contracts\LoggerRepository;
  */
 final class Prune extends Command
 {
-    protected $signature = 'deployer:prune {--keep=5} {--verbosity=1}';
+    protected $signature = 'deployer:prune {--keep=5}';
 
     protected $description = 'Prunes old bundles from the bundles directory.';
 

--- a/src/Console/Commands/Rollback.php
+++ b/src/Console/Commands/Rollback.php
@@ -18,8 +18,7 @@ use Actengage\Deployer\CurrentBundleManager;
 final class Rollback extends Command
 {
     protected $signature = 'deployer:rollback
-                            {step=1}
-                            {--verbosity=1}';
+                            {step=1}';
 
     protected $description = 'Deploys an artifact bundle a number of steps before the current one.';
 

--- a/src/Console/Commands/Status.php
+++ b/src/Console/Commands/Status.php
@@ -16,7 +16,7 @@ use Actengage\Deployer\CurrentBundleManager;
  */
 final class Status extends Command
 {
-    protected $signature = 'deployer:status {--limit=10} {--verbosity=1}';
+    protected $signature = 'deployer:status {--limit=10}';
 
     protected $description = 'Displays information about the current deployment.';
 


### PR DESCRIPTION
This resolves #25 by hooking into the built-in Artisan `-v`, `-vv`, and `-vvv` switches, rather than having our own `--verbosity` option.