### PR TITLE
Add `--include-invalid` option to `deployer:prune`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ php artisan deployer:prune --keep 5
 
 After a while, your bundles directory may become bloated with old artifact bundles. This command may be invoked to automatically delete all but the given number of most recent ones.
 
+By default, invalid bundles (that is, bundle with missing/malformed manifests) will be ignored. To remove them, you may invoke `deployer:prune` with the `--include-invalid` flag.
+
 ## Bundle Structure
 
 An artifact bundle in the context of the `deployer` package is simply a directory. That directory contains one or more "artifacts" (which may themselves be either directories or plain files) and a `manifest.json` file.

--- a/src/BundlePruner.php
+++ b/src/BundlePruner.php
@@ -3,6 +3,8 @@
 namespace Actengage\Deployer;
 
 use Actengage\Deployer\Contracts\LoggerRepository;
+use Actengage\Deployer\Contracts\PathProvider;
+use Illuminate\Support\Collection;
 
 /**
  * Prunes old bundles.
@@ -13,6 +15,7 @@ class BundlePruner
 {
     public function __construct(
         protected FilesystemUtility $filesystem,
+        protected PathProvider $paths,
         protected BundlesAccessor $bundles,
         protected LoggerRepository $logger
     ) {
@@ -21,22 +24,72 @@ class BundlePruner
     /**
      * Prunes old bundles.
      *
-     * Removes all bundles from disk except for the given number of most recent ones to keep.
+     * Removes all valid bundles from disk except for the given number of most recent ones to keep.
      *
-     * Note that bundles with missing or malformed manifests will not be included (because it is impossible to
-     * accurately determine their timestamps).
+     * This method can also optionally remove invalid bundles (id est, bundles with missing or malformed manifests).
      *
+     * @param  int  $keep the number of most recent bundles to keep.
+     * @param  bool  $includeInvalid whether to remove all invalid bundles, in addition to pruning the valid ones.
+     * @return int the total number of bundles (both valid and invalid) that were deleted.
+     */
+    public function prune(int $keep, bool $includeInvalid = false): int
+    {
+        $bundles = $this->bundles->all();
+        $deleted = 0;
+
+        $deleted += $this->pruneValidBundles($bundles, $keep);
+        if ($includeInvalid) {
+            $deleted += $this->pruneInvalidBundles($bundles);
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Prunes the given bundles.
+     *
+     * Removes all the given bundles from disk except for the given number of most recent ones to keep.
+     *
+     * @param  Collection  $bundles the bundles to prune. Note that this collection itself will not be modified; it is the files on disk that will be deleted.
      * @param  int  $keep the number of most recent bundles to keep.
      * @return int the number of bundles that were deleted.
      */
-    public function prune(int $keep): int
+    protected function pruneValidBundles(Collection $bundles, int $keep): int
     {
         $deleted = 0;
 
-        $bundlesToDelete = $this->bundles->all()->skip($keep);
+        $bundlesToDelete = $bundles->skip($keep);
         $bundlesToDelete->each(function (Bundle $bundle) use (&$deleted) {
             $this->logger->get()->debug("Deleting bundle at $bundle->path");
             $this->filesystem->delete($bundle->path);
+            $deleted++;
+        });
+
+        return $deleted;
+    }
+
+    /**
+     * Prunes invalid bundles.
+     *
+     * Removes all invalid bundles from disk.
+     *
+     * Invalid bundles comprise all bundles except those whose paths exist in the given collection of valid bundles.
+     *
+     * @param  Collectioni  $bundles the collection of valid bundles that should *not* be removed.
+     * @return int the number of invalid bundles that were deleted.
+     */
+    protected function pruneInvalidBundles(Collection $bundles): int
+    {
+        $deleted = 0;
+
+        $this->filesystem->eachChild($this->paths->bundlesDir(), function ($file) use ($bundles, &$deleted) {
+            if ($bundles->first(fn ($b) => $b->path === $file)) {
+                // This is a valid bundle; skip it.
+                return;
+            }
+
+            $this->logger->get()->debug("Deleting invalid bundle at $file");
+            $this->filesystem->delete($file);
             $deleted++;
         });
 

--- a/src/Console/Commands/Prune.php
+++ b/src/Console/Commands/Prune.php
@@ -13,7 +13,8 @@ use Actengage\Deployer\Contracts\LoggerRepository;
 final class Prune extends Command
 {
     protected $signature = 'deployer:prune
-                            {--keep=5 : The number of most recent bundles to keep.}';
+                            {--keep=5 : The number of most recent bundles to keep.}
+                            {--include-invalid : Specifies that bundles with missing/malformed manifests should be removed.}';
 
     protected $description = 'Prunes old bundles from the bundles directory.';
 
@@ -21,7 +22,7 @@ final class Prune extends Command
     {
         $logger->set($this->createLogger());
 
-        $deleted = $pruner->prune((int) $this->option('keep'));
+        $deleted = $pruner->prune((int) $this->option('keep'), $this->option('include-invalid'));
 
         if ($deleted > 0) {
             $this->info("Removed $deleted bundles.");

--- a/tests/Feature/BundlePruningTest.php
+++ b/tests/Feature/BundlePruningTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 
 class BundlePruningTest extends TestCase
 {
-    public function test__keepNone()
+    public function test__onlyValid__keepNone()
     {
         $pruner = $this->makePruner();
 
@@ -19,7 +19,7 @@ class BundlePruningTest extends TestCase
         $this->assertTrue(file_exists($this->bundlesDir().'without_manifest'));
     }
 
-    public function test__keepOne()
+    public function test__onlyValid__keepOne()
     {
         $pruner = $this->makePruner();
 
@@ -28,6 +28,17 @@ class BundlePruningTest extends TestCase
         $this->assertEquals(1, $deleted);
         $this->assertEquals(2, $this->filesystem()->countDirChildren($this->bundlesDir()));
         $this->assertTrue(file_exists($this->bundlesDir().'without_manifest'));
+        $this->assertTrue(file_exists($this->bundlesDir().'bundle_two'));
+    }
+
+    public function test__includeInvalid__keepOne()
+    {
+        $pruner = $this->makePruner();
+
+        $deleted = $pruner->prune(1, true);
+
+        $this->assertEquals(2, $deleted);
+        $this->assertEquals(1, $this->filesystem()->countDirChildren($this->bundlesDir()));
         $this->assertTrue(file_exists($this->bundlesDir().'bundle_two'));
     }
 


### PR DESCRIPTION
Add an `--include-invalid` option to `deployer:prune` to delete invalid bundles.

This resolves #34.