### PR TITLE
Switch to "extra" metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,10 @@ The manifest file has the following schema (without comments, of course):
   "version": "v1.1.13",
   // REQUIRED. A Unix timestamp representing the time at which this bundle was built.
   "bundled_at": 1660748148,
-  // A Unix timestamp representing the time at which the commit was create for which this bundle was built.
-  "committed_at": 1660747824,
-  // The Git ref for which this bundle was built, if applicable.
-  "git_ref": "refs/tags/v1.1.13",
-  // A string indicating the CI/CD "job" that built this bundle, if applicable.
-  "ci_job": "production"
+  // Extra properties with non-standard metadata. You can put whatever proeprties you want in here.
+  "extra": {
+    // custom properties
+  }
 }
 ```
 

--- a/src/Bundle.php
+++ b/src/Bundle.php
@@ -3,6 +3,7 @@
 namespace Actengage\Deployer;
 
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -27,10 +28,7 @@ final class Bundle
      * @param  ?string  $version the release version for which this bundle was built. This likely will only apply to
      * production builds.
      * @param  Carbon  $bundled_at the datetime at which this bundle was built.
-     * @param  ?Carbon  $committed_at the datetime at which the Git commit for which this bundle was built was committed.
-     * @param  ?string  $git_ref a Git reference (e.g. `"refs/heads/master"`) associated with the bundle.
-     * @param  ?string  $ci_job if the bundle was built in a CI environment, the name of the CI job or runner that built
-     * the bundle.
+     * @param  ?Collection $extra an array of extra, non-standard metadata about the bundle.
      */
     public function __construct(
         public string $path,
@@ -39,9 +37,7 @@ final class Bundle
         public ?string $env,
         public ?string $version,
         public Carbon $bundled_at,
-        public ?Carbon $committed_at,
-        public ?string $git_ref,
-        public ?string $ci_job
+        public ?Collection $extra
     ) {
     }
 
@@ -94,25 +90,12 @@ final class Bundle
             env: $array->get('env'),
             version: $array->get('version'),
             bundled_at: Carbon::createFromTimestamp($array->get('bundled_at')),
-            committed_at: self::tryParseTimestamp($array->get('committed_at')),
-            git_ref: $array->get('git_ref'),
-            ci_job: $array->get('ci_job'),
+            extra: static::tryCollect($array->get('extra'))
         );
     }
 
-    /**
-     * Tries to parse a timestamp.
-     *
-     * Attempts to parse the given string into a timestamp. If the string is falsy, then `null` is returned.
-     *
-     * @return ?Carbon
-     */
-    private static function tryParseTimestamp(?string $input): ?Carbon
+    protected static function tryCollect(?array $input): ?Collection
     {
-        if (! $input) {
-            return null;
-        }
-
-        return Carbon::createFromTimestamp($input);
+        return $input ? collect($input) : null;
     }
 }

--- a/tests/Unit/BundleTest.php
+++ b/tests/Unit/BundleTest.php
@@ -17,9 +17,11 @@ class BundleTest extends TestCase
             'env' => 'production',
             'version' => 'v1',
             'bundled_at' => 1660327468,
-            'committed_at' => 1660327484,
-            'git_ref' => 'master',
-            'ci_job' => 'build',
+            'extra' => [
+                'committed_at' => 1660327484,
+                'git_ref' => 'master',
+                'ci_job' => 'build',
+            ]
         ]));
 
         $this->assertEquals('/some/random/path', $bundle->path);
@@ -28,9 +30,9 @@ class BundleTest extends TestCase
         $this->assertEquals('production', $bundle->env);
         $this->assertEquals('v1', $bundle->version);
         $this->assertEquals(Carbon::parse('Fri Aug 12 2022 18:04:28 GMT+0000'), $bundle->bundled_at);
-        $this->assertEquals(Carbon::parse('Fri Aug 12 2022 18:04:44 GMT+0000'), $bundle->committed_at);
-        $this->assertEquals('master', $bundle->git_ref);
-        $this->assertEquals('build', $bundle->ci_job);
+        $this->assertEquals('1660327484', $bundle->extra->get('committed_at'));
+        $this->assertEquals('master', $bundle->extra->get('git_ref'));
+        $this->assertEquals('build', $bundle->extra->get('ci_job'));
     }
 
     public function test__fromJson__withoutOptional__nullifies()
@@ -42,9 +44,7 @@ class BundleTest extends TestCase
         $this->assertNull($bundle->initiator);
         $this->assertNull($bundle->env);
         $this->assertNull($bundle->version);
-        $this->assertNull($bundle->committed_at);
-        $this->assertNull($bundle->git_ref);
-        $this->assertNull($bundle->ci_job);
+        $this->assertNull($bundle->extra);
     }
 
     public function test__fromJson__withoutRequired__throwsException()


### PR DESCRIPTION
Rather than trying to anticipate various reference metadata, use an "extra" field in bundle manifests.

Fixes #35.