### PR TITLE
Filter ANSI output

### DIFF
--- a/src/AnsiFilter.php
+++ b/src/AnsiFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Actengage\Deployer;
+
+use Actengage\Deployer\Contracts\AnsiFilter as AnsiFilterInterface;
+
+/**
+ * Filters ANSI usage.
+ * 
+ * An implementatino of {@see Actengage\Contracts\AnsiFilter} that simply manages whether ANSI is allowed.
+ */
+class AnsiFilter implements AnsiFilterInterface
+{
+    protected bool $allowed = true;
+
+    public function allow(bool $allowed = true): void
+    {
+        $this->allowed = $allowed;
+    }
+
+    public function disallow(): void
+    {
+        $this->allowed = false;
+    }
+
+    public function allowed(): bool
+    {
+        return $this->allowed;
+    }
+}

--- a/src/Console/Commands/Deploy.php
+++ b/src/Console/Commands/Deploy.php
@@ -5,6 +5,7 @@ namespace Actengage\Deployer\Console\Commands;
 use Actengage\Deployer\Bundle;
 use Actengage\Deployer\BundleDeployer;
 use Actengage\Deployer\BundlesAccessor;
+use Actengage\Deployer\Contracts\AnsiFilter;
 use Actengage\Deployer\Contracts\LoggerRepository;
 use Actengage\Deployer\CurrentBundleManager;
 use Illuminate\Support\Collection;
@@ -27,12 +28,11 @@ final class Deploy extends Command
     protected $description = 'Deploys an artifact bundle.';
 
     public function handle(
-        LoggerRepository $logger,
         BundlesAccessor $bundles,
         CurrentBundleManager $currentBundle,
-        BundleDeployer $deployer
+        BundleDeployer $deployer,
     ): int {
-        $logger->set($this->createLogger());
+        $this->setup();
 
         $bundle = $this->getBundle($bundles->all(), $currentBundle);
 

--- a/src/Console/Commands/ListBundles.php
+++ b/src/Console/Commands/ListBundles.php
@@ -5,6 +5,7 @@ namespace Actengage\Deployer\Console\Commands;
 use Actengage\Deployer\AnsiUtility;
 use Actengage\Deployer\Bundle;
 use Actengage\Deployer\BundlesAccessor;
+use Actengage\Deployer\Contracts\AnsiFilter;
 use Actengage\Deployer\Contracts\LoggerRepository;
 use Actengage\Deployer\CurrentBundleManager;
 
@@ -22,12 +23,11 @@ final class ListBundles extends Command
     protected $description = 'Lists all deployable artifact bundles.';
 
     public function handle(
-        LoggerRepository $logger,
         BundlesAccessor $bundles,
         CurrentBundleManager $currentBundle,
-        AnsiUtility $ansi
+        AnsiUtility $ansi,
     ): int {
-        $logger->set($this->createLogger());
+        $this->setup();
 
         $headers = ['#', 'Bundled At', 'Initiated By', 'Version', 'Commit'];
         $rows = [];

--- a/src/Console/Commands/Prune.php
+++ b/src/Console/Commands/Prune.php
@@ -3,6 +3,7 @@
 namespace Actengage\Deployer\Console\Commands;
 
 use Actengage\Deployer\BundlePruner;
+use Actengage\Deployer\Contracts\AnsiFilter;
 use Actengage\Deployer\Contracts\LoggerRepository;
 
 /**
@@ -18,9 +19,8 @@ final class Prune extends Command
 
     protected $description = 'Prunes old bundles from the bundles directory.';
 
-    public function handle(LoggerRepository $logger, BundlePruner $pruner): int
-    {
-        $logger->set($this->createLogger());
+    public function handle(BundlePruner $pruner): int {
+        $this->setup();
 
         $deleted = $pruner->prune((int) $this->option('keep'), $this->option('include-invalid'));
 

--- a/src/Console/Commands/Rollback.php
+++ b/src/Console/Commands/Rollback.php
@@ -5,6 +5,7 @@ namespace Actengage\Deployer\Console\Commands;
 use Actengage\Deployer\Bundle;
 use Actengage\Deployer\BundleDeployer;
 use Actengage\Deployer\BundlesAccessor;
+use Actengage\Deployer\Contracts\AnsiFilter;
 use Actengage\Deployer\Contracts\LoggerRepository;
 use Actengage\Deployer\CurrentBundleManager;
 
@@ -23,12 +24,11 @@ final class Rollback extends Command
     protected $description = 'Deploys an artifact bundle a number of steps before the current one.';
 
     public function handle(
-        LoggerRepository $logger,
         BundlesAccessor $bundles,
         CurrentBundleManager $currentBundle,
-        BundleDeployer $deployer
+        BundleDeployer $deployer,
     ): int {
-        $logger->set($this->createLogger());
+        $this->setup();
 
         $all = $bundles->all();
         $currentNumber = $all->search(fn ($b) => $currentBundle->is($b));

--- a/src/Console/Commands/Status.php
+++ b/src/Console/Commands/Status.php
@@ -6,6 +6,7 @@ use Actengage\Deployer\AnsiColor;
 use Actengage\Deployer\AnsiUtility;
 use Actengage\Deployer\Bundle;
 use Actengage\Deployer\BundlesAccessor;
+use Actengage\Deployer\Contracts\AnsiFilter;
 use Actengage\Deployer\Contracts\LoggerRepository;
 use Actengage\Deployer\CurrentBundleManager;
 
@@ -21,12 +22,11 @@ final class Status extends Command
     protected $description = 'Displays information about the current deployment.';
 
     public function handle(
-        LoggerRepository $logger,
         BundlesAccessor $bundles,
         CurrentBundleManager $currentBundle,
-        AnsiUtility $ansi
+        AnsiUtility $ansi,
     ): int {
-        $logger->set($this->createLogger());
+        $this->setup();
 
         $all = $bundles->all();
         $currentNumber = $all->search(fn ($b) => $currentBundle->is($b));

--- a/src/Contracts/AnsiFilter.php
+++ b/src/Contracts/AnsiFilter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Actengage\Deployer\Contracts;
+
+/**
+ * Filters ANSI usage.
+ * 
+ * Defines a class that is capable of filtering the output of special ANSI codes.
+ * 
+ * Currently, the only filtering involves turning ANSI output on and off.
+ */
+interface AnsiFilter
+{
+    public function allow(bool $allowed = true): void;
+
+    public function disallow(): void;
+
+    public function allowed(): bool;
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,8 @@ use Actengage\Deployer\Console\Commands\ListBundles;
 use Actengage\Deployer\Console\Commands\Prune;
 use Actengage\Deployer\Console\Commands\Rollback;
 use Actengage\Deployer\Console\Commands\Status;
+use Actengage\Deployer\Contracts\AnsiFilter as AnsiFilterInterface;
+use Actengage\Deployer\AnsiFilter;
 use Actengage\Deployer\Contracts\LoggerRepository as LoggerRepositoryInterface;
 use Actengage\Deployer\Contracts\PathProvider as PathProviderInterface;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
@@ -40,6 +42,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(BundlePruner::class);
         $this->app->singleton(PathProviderInterface::class, PathProvider::class);
         $this->app->singleton(LoggerRepositoryInterface::class, LoggerRepository::class);
+        $this->app->singleton(AnsiFilterInterface::class, AnsiFilter::class);
 
         $this->app->when(PathProvider::class)
             ->needs('$deploymentDir')

--- a/tests/Unit/AnsiUtilityTest.php
+++ b/tests/Unit/AnsiUtilityTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit;
 
+use Actengage\Deployer\AnsiColor;
+use Actengage\Deployer\AnsiFilter;
 use Actengage\Deployer\AnsiUtility;
 use InvalidArgumentException;
 use Tests\TestCase;
@@ -54,8 +56,35 @@ class AnsiUtilityTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    private function makeAnsi(): AnsiUtility
+    public function test__colored()
     {
-        return new AnsiUtility;
+        $expected = "\033[32mhi there\033[39m";
+        $actual = $this->makeAnsi()->colored('hi there', AnsiColor::GREEN);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test__bold__filtered()
+    {
+        $expected = "original input";
+        $actual = $this->makeAnsi(false)->bold("original input");
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test__colored__filtered()
+    {
+        $expected = "original input";
+        $actual = $this->makeAnsi(false)->colored("original input", AnsiColor::RED);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function makeAnsi(bool $allowed = true): AnsiUtility
+    {
+        $filter = new AnsiFilter;
+        $filter->allow($allowed);
+
+        return new AnsiUtility($filter);
     }
 }


### PR DESCRIPTION
Update all commands to respect the `--no-ansi` flag.

In the process, add a setup() method to Command as a different approach to setting up dependencies.

Fixes #33.