### PR TITLE
Fix list bug

### DIFF
--- a/src/Console/Commands/ListBundles.php
+++ b/src/Console/Commands/ListBundles.php
@@ -63,6 +63,6 @@ final class ListBundles extends Command
 
     private function row(array $columns, bool $current, AnsiUtility $ansi): array
     {
-        return array_map(fn ($c) => $current ? $ansi->bold($c) : $c, $columns);
+        return array_map(fn ($c) => $current ? $ansi->bold($c ?? '') : $c, $columns);
     }
 }


### PR DESCRIPTION
Fix a bug where empty columns in the `deployer:list` command would throw an error upon being bolded.